### PR TITLE
Update Nethermind executable name

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ const commander = require('commander');
 // const program = new commander.Command();
 
 const applications = {
-  runner: 'Nethermind.Runner',
-  cli: 'Nethermind.Cli'
+  runner: 'nethermind',
+  cli: 'nethermind-cli'
 }
 
 // program

--- a/test/inquirer_stub.test.js
+++ b/test/inquirer_stub.test.js
@@ -24,7 +24,7 @@ describe('Applications', function() {
   });
 
   it('applications should include Runner and Cli', function() {
-      expect(index.applications).to.include({ runner: './Nethermind.Runner', cli: './Nethermind.Cli' });
+      expect(index.applications).to.include({ runner: './nethermind', cli: './nethermind-cli' });
   });
 });
 


### PR DESCRIPTION
- Renamed `Nethermind.Runner` to `nethermind`
- Renamed `Nethermind.Cli` to `nethermind-cli`

To be merged right before the release of Nethermind with the abovementioned change.